### PR TITLE
Keep used-defined functions so they can be called by subsequent compilations

### DIFF
--- a/app/elm/Compiler/Ast.elm
+++ b/app/elm/Compiler/Ast.elm
@@ -34,9 +34,7 @@ type alias Program =
 -}
 type alias CompiledProgram =
     { instructions : List Instruction
-    , functionTable : Dict String Int
     , compiledFunctions : List CompiledFunction
-    , startAddress : Int
     }
 
 
@@ -510,28 +508,11 @@ compileProgram { functions, body } =
         compiledFunctions =
             List.map compileFunction functions
 
-        compiledFunctionInstances =
-            List.concatMap .instances compiledFunctions
-
-        ( functionTable, startAddress ) =
-            List.foldl
-                (\f ( acc, address ) ->
-                    ( Dict.insert f.mangledName address acc
-                    , address + List.length f.body
-                    )
-                )
-                ( Dict.empty, 0 )
-                compiledFunctionInstances
-
         instructions =
-            List.append
-                (List.concatMap .body compiledFunctionInstances)
-                (List.concatMap (compileInContext Statement) body)
+            List.concatMap (compileInContext Statement) body
     in
     { instructions = instructions
-    , functionTable = functionTable
     , compiledFunctions = compiledFunctions
-    , startAddress = startAddress
     }
 
 

--- a/app/elm/Compiler/Ast/Introspect.elm
+++ b/app/elm/Compiler/Ast/Introspect.elm
@@ -8,12 +8,11 @@ module Compiler.Ast.Introspect exposing
     )
 
 import Vm.Introspect as I
-import Vm.Vm exposing (Vm)
 
 
 type Introspect
-    = Introspect0 (I.Introspect0 Vm)
-    | Introspect1 (I.Introspect1 Vm)
+    = Introspect0 I.Introspect0
+    | Introspect1 I.Introspect1
 
 
 all : List Introspect
@@ -48,6 +47,6 @@ arguments introspect =
             1
 
 
-templateVariable : I.Introspect1 Vm
+templateVariable : I.Introspect1
 templateVariable =
     { name = "?", f = I.templateVariable }

--- a/app/elm/Compiler/Linker.elm
+++ b/app/elm/Compiler/Linker.elm
@@ -1,0 +1,47 @@
+module Compiler.Linker exposing (LinkedProgram, linkProgram)
+
+import Compiler.Ast exposing (CompiledFunction, CompiledProgram)
+import Dict exposing (Dict)
+import Vm.Instruction exposing (Instruction)
+
+
+{-| Represent a linked program.
+-}
+type alias LinkedProgram =
+    { instructions : List Instruction
+    , functionTable : Dict String Int
+    , compiledFunctions : List CompiledFunction
+    , startAddress : Int
+    }
+
+
+linkProgram : List CompiledFunction -> CompiledProgram -> LinkedProgram
+linkProgram existingCompiledFunctions program =
+    let
+        compiledFunctions =
+            program.compiledFunctions
+                |> List.append existingCompiledFunctions
+
+        compiledFunctionInstances =
+            List.concatMap .instances compiledFunctions
+
+        ( functionTable, startAddress ) =
+            List.foldl
+                (\f ( acc, address ) ->
+                    ( Dict.insert f.mangledName address acc
+                    , address + List.length f.body
+                    )
+                )
+                ( Dict.empty, 0 )
+                compiledFunctionInstances
+
+        instructions =
+            List.append
+                (List.concatMap .body compiledFunctionInstances)
+                program.instructions
+    in
+    { instructions = instructions
+    , functionTable = functionTable
+    , compiledFunctions = compiledFunctions
+    , startAddress = startAddress
+    }

--- a/app/elm/Vm/Instruction.elm
+++ b/app/elm/Vm/Instruction.elm
@@ -1,0 +1,41 @@
+module Vm.Instruction exposing (Instruction(..))
+
+import Vm.Command as C
+import Vm.Exception exposing (Exception)
+import Vm.Introspect as I
+import Vm.Primitive as P
+import Vm.Type as Type
+
+
+{-| Represent instructions a `Vm` can execute.
+-}
+type Instruction
+    = PushValue Type.Value
+    | PushVariable String
+    | StoreVariable String
+    | LocalVariable String
+    | Introspect0 I.Introspect0
+    | Introspect1 I.Introspect1
+    | Eval1 P.Primitive1
+    | Eval2 P.Primitive2
+    | Command0 C.Command0
+    | Command1 C.Command1
+    | Command2 C.Command2
+    | PushLoopScope
+    | EnterLoopScope
+    | PopLoopScope
+    | PushTemplateScope
+    | EnterTemplateScope
+    | PopTemplateScope
+    | PushLocalScope
+    | PopLocalScope
+    | JumpIfFalse Int
+    | JumpIfTrue Int
+    | Jump Int
+    | Call Int
+    | CallByName String
+    | PushVoid
+    | Return
+    | CheckReturn
+    | Duplicate
+    | Raise Exception

--- a/app/elm/Vm/Introspect.elm
+++ b/app/elm/Vm/Introspect.elm
@@ -5,37 +5,31 @@ module Vm.Introspect exposing
     , templateVariable
     )
 
-{-| This module provides primitives for accessing the current state of the
-virtual machine.
-
-It cannot import the `Vm` type as that would form a circular dependency: one of
-the virtual machine’s instructions depends on the first type alias.
-
-Thus, all types are parametrized.
-
+{-| This module provides primitives for accessing the current state of template
+and loop scopes in a virtual machine.
 -}
 
 import Vm.Scope as Scope exposing (Scope)
 import Vm.Type as Type
 
 
-type alias Introspect0 a =
+type alias Introspect0 =
     { name : String
-    , f : a -> Result Scope.Error Type.Value
+    , f : List Scope -> Result Scope.Error Type.Value
     }
 
 
-type alias Introspect1 a =
+type alias Introspect1 =
     { name : String
-    , f : Type.Value -> a -> Result Scope.Error Type.Value
+    , f : Type.Value -> List Scope -> Result Scope.Error Type.Value
     }
 
 
-repcount : { a | scopes : List Scope } -> Result Scope.Error Type.Value
-repcount vm =
-    Ok <| Type.Int (Scope.repcount vm.scopes)
+repcount : List Scope -> Result Scope.Error Type.Value
+repcount scopes =
+    Ok <| Type.Int (Scope.repcount scopes)
 
 
-templateVariable : Type.Value -> { a | scopes : List Scope } -> Result Scope.Error Type.Value
-templateVariable value vm =
-    Scope.templateVariable value vm.scopes
+templateVariable : Type.Value -> List Scope -> Result Scope.Error Type.Value
+templateVariable value scopes =
+    Scope.templateVariable value scopes

--- a/app/elm/Vm/Vm.elm
+++ b/app/elm/Vm/Vm.elm
@@ -14,7 +14,8 @@ machine as well as functions for running it.
 -}
 
 import Array exposing (Array)
-import Compiler.Ast exposing (CompiledFunction, CompiledProgram)
+import Compiler.Ast exposing (CompiledFunction)
+import Compiler.Linker exposing (LinkedProgram)
 import Dict exposing (Dict)
 import Environment exposing (Environment)
 import Json.Encode as E
@@ -56,7 +57,7 @@ empty =
 
 {-| Initialize a `Vm` with a list of instructions and a program counter.
 -}
-initialize : CompiledProgram -> Vm
+initialize : LinkedProgram -> Vm
 initialize { instructions, functionTable, compiledFunctions, startAddress } =
     { instructions = Array.fromList instructions
     , programCounter = startAddress

--- a/app/elm/Vm/Vm.elm
+++ b/app/elm/Vm/Vm.elm
@@ -1,6 +1,5 @@
 module Vm.Vm exposing
-    ( CompiledProgram
-    , State(..)
+    ( State(..)
     , Vm
     , empty
     , initialize
@@ -15,6 +14,7 @@ machine as well as functions for running it.
 -}
 
 import Array exposing (Array)
+import Compiler.Ast exposing (CompiledFunction, CompiledProgram)
 import Dict exposing (Dict)
 import Environment exposing (Environment)
 import Json.Encode as E
@@ -29,15 +29,6 @@ import Vm.Stack as Stack exposing (Stack)
 import Vm.Type as Type
 
 
-{-| Represent a compiled program.
--}
-type alias CompiledProgram =
-    { instructions : List Instruction
-    , functionTable : Dict String Int
-    , startAddress : Int
-    }
-
-
 {-| Represent a stack based virtual machine.
 -}
 type alias Vm =
@@ -47,6 +38,7 @@ type alias Vm =
     , scopes : List Scope
     , environment : Environment
     , functionTable : Dict String Int
+    , compiledFunctions : List CompiledFunction
     }
 
 
@@ -54,19 +46,25 @@ type alias Vm =
 -}
 empty : Vm
 empty =
-    initialize { instructions = [], functionTable = Dict.empty, startAddress = 0 }
+    initialize
+        { instructions = []
+        , functionTable = Dict.empty
+        , compiledFunctions = []
+        , startAddress = 0
+        }
 
 
 {-| Initialize a `Vm` with a list of instructions and a program counter.
 -}
 initialize : CompiledProgram -> Vm
-initialize { instructions, functionTable, startAddress } =
+initialize { instructions, functionTable, compiledFunctions, startAddress } =
     { instructions = Array.fromList instructions
     , programCounter = startAddress
     , stack = []
     , scopes = Scope.empty
     , environment = Environment.empty
     , functionTable = functionTable
+    , compiledFunctions = compiledFunctions
     }
 
 

--- a/tests/Test/Ast.elm
+++ b/tests/Test/Ast.elm
@@ -5,9 +5,9 @@ import Expect
 import Test exposing (..)
 import Vm.Command as C
 import Vm.Exception as Exception
+import Vm.Instruction exposing (Instruction(..))
 import Vm.Primitive as P
 import Vm.Type as Type
-import Vm.Vm exposing (Instruction(..))
 
 
 intLiteral =

--- a/tests/Test/Compiler.elm
+++ b/tests/Test/Compiler.elm
@@ -1,9 +1,9 @@
 module Test.Compiler exposing (..)
 
-import Compiler.Ast as Ast exposing (Node(..))
+import Compiler.Ast as Ast
 import Expect
 import Test exposing (Test, describe, test)
-import Vm.Instruction as Instruction exposing (Instruction(..))
+import Vm.Instruction exposing (Instruction(..))
 import Vm.Type as Type
 
 
@@ -16,7 +16,7 @@ compileFunction =
                     function =
                         { name = "foo"
                         , requiredArguments = [ "bar" ]
-                        , optionalArguments = [ ( "baz", Value <| Type.Word "baz" ) ]
+                        , optionalArguments = [ ( "baz", Ast.Value <| Type.Word "baz" ) ]
                         , body = []
                         }
 
@@ -24,31 +24,36 @@ compileFunction =
                         Ast.compileFunction function
                 in
                 Expect.equal
-                    [ { name = "foo2"
-                      , body =
-                            [ PushLocalScope
-                            , LocalVariable "bar"
-                            , StoreVariable "bar"
-                            , LocalVariable "baz"
-                            , StoreVariable "baz"
-                            , PushVoid
-                            , PopLocalScope
-                            , Instruction.Return
-                            ]
-                      }
-                    , { name = "foo1"
-                      , body =
-                            [ PushLocalScope
-                            , LocalVariable "bar"
-                            , StoreVariable "bar"
-                            , LocalVariable "baz"
-                            , PushValue (Type.Word "baz")
-                            , StoreVariable "baz"
-                            , PushVoid
-                            , PopLocalScope
-                            , Instruction.Return
-                            ]
-                      }
-                    ]
+                    { name = "foo"
+                    , requiredArguments = [ "bar" ]
+                    , optionalArguments = [ "baz" ]
+                    , instances =
+                        [ { mangledName = "foo2"
+                          , body =
+                                [ PushLocalScope
+                                , LocalVariable "bar"
+                                , StoreVariable "bar"
+                                , LocalVariable "baz"
+                                , StoreVariable "baz"
+                                , PushVoid
+                                , PopLocalScope
+                                , Return
+                                ]
+                          }
+                        , { mangledName = "foo1"
+                          , body =
+                                [ PushLocalScope
+                                , LocalVariable "bar"
+                                , StoreVariable "bar"
+                                , LocalVariable "baz"
+                                , PushValue (Type.Word "baz")
+                                , StoreVariable "baz"
+                                , PushVoid
+                                , PopLocalScope
+                                , Return
+                                ]
+                          }
+                        ]
+                    }
                     compiledFunctions
         ]

--- a/tests/Test/Compiler.elm
+++ b/tests/Test/Compiler.elm
@@ -3,8 +3,8 @@ module Test.Compiler exposing (..)
 import Compiler.Ast as Ast exposing (Node(..))
 import Expect
 import Test exposing (Test, describe, test)
+import Vm.Instruction as Instruction exposing (Instruction(..))
 import Vm.Type as Type
-import Vm.Vm as Vm exposing (Instruction(..))
 
 
 compileFunction : Test
@@ -33,7 +33,7 @@ compileFunction =
                             , StoreVariable "baz"
                             , PushVoid
                             , PopLocalScope
-                            , Vm.Return
+                            , Instruction.Return
                             ]
                       }
                     , { name = "foo1"
@@ -46,7 +46,7 @@ compileFunction =
                             , StoreVariable "baz"
                             , PushVoid
                             , PopLocalScope
-                            , Vm.Return
+                            , Instruction.Return
                             ]
                       }
                     ]

--- a/tests/Test/Parser.elm
+++ b/tests/Test/Parser.elm
@@ -1,22 +1,13 @@
 module Test.Parser exposing (..)
 
 import Compiler.Ast as Ast
-import Compiler.Parser as Parser
+import Compiler.Parser as Parser exposing (defaultState)
 import Compiler.Parser.Value as Value
-import Dict
 import Expect exposing (Expectation)
 import Parser.Advanced as Parser exposing (DeadEnd)
 import Test exposing (..)
 import Vm.Command as C
 import Vm.Type as Type
-
-
-defaultState : Parser.State
-defaultState =
-    { userDefinedFunctions = Dict.empty
-    , parsedBody = []
-    , inFunction = False
-    }
 
 
 value : Test

--- a/tests/Test/Run.elm
+++ b/tests/Test/Run.elm
@@ -490,3 +490,29 @@ environmentIsKept =
                     List.length env.objects
             in
             Expect.equal numberOfObjects 2
+
+
+functionIsKept : Test
+functionIsKept =
+    test "a function is kept and can be called in a subsequent run" <|
+        \_ ->
+            let
+                firstProgram =
+                    "to drawLine\npendown forward 90\nend\n"
+
+                secondProgram =
+                    "drawLine"
+
+                logo =
+                    Logo.empty
+                        |> Logo.run firstProgram
+                        |> Logo.run secondProgram
+
+                env =
+                    Logo.getEnvironment logo
+
+                -- The above program will create 1 line.
+                numberOfObjects =
+                    List.length env.objects
+            in
+            Expect.equal numberOfObjects 1

--- a/tests/Test/Vm.elm
+++ b/tests/Test/Vm.elm
@@ -25,6 +25,7 @@ emptyVm =
     , scopes = Scope.empty
     , environment = Environment.empty
     , functionTable = Dict.empty
+    , compiledFunctions = []
     }
 
 

--- a/tests/Test/Vm.elm
+++ b/tests/Test/Vm.elm
@@ -8,12 +8,13 @@ import Expect
 import Test exposing (..)
 import Vm.Command as C
 import Vm.Exception as Exception
+import Vm.Instruction exposing (Instruction(..))
 import Vm.Introspect as I
 import Vm.Primitive as P
 import Vm.Scope as Scope
 import Vm.Stack as Stack
 import Vm.Type as Type
-import Vm.Vm exposing (..)
+import Vm.Vm exposing (State(..), Vm, run)
 
 
 emptyVm : Vm
@@ -149,7 +150,7 @@ vmWithPrintLoop =
                     , Duplicate
                     , Eval1 { name = "integerp", f = P.integerp }
                     , JumpIfTrue 2
-                    , Vm.Vm.Raise (Exception.WrongInput "repeat")
+                    , Raise (Exception.WrongInput "repeat")
                     , PushLoopScope
                     , EnterLoopScope
                     , JumpIfTrue 4


### PR DESCRIPTION
- Extract `Instruction` to own module
- Extend `CompiledProgram` and `CompiledFunction`
- Pass existing functions to parser
- Extract linking to `Compiler.Linker`
