### PR TITLE
Raise error on duplicate definition

### DIFF
--- a/app/elm/Compiler/Parser.elm
+++ b/app/elm/Compiler/Parser.elm
@@ -90,7 +90,10 @@ toplevel_ state =
 
 defineFunctionUnlessDefined : State -> Ast.Function -> State
 defineFunctionUnlessDefined state newFunction =
-    if Dict.member newFunction.name state.newFunctions then
+    if
+        Dict.member newFunction.name state.newFunctions
+            || Dict.member newFunction.name state.existingFunctions
+    then
         let
             parsedBody =
                 state.parsedBody

--- a/tests/Test/Run.elm
+++ b/tests/Test/Run.elm
@@ -516,3 +516,25 @@ functionIsKept =
                     List.length env.objects
             in
             Expect.equal numberOfObjects 1
+
+
+duplicateDefinition : Test
+duplicateDefinition =
+    test "prints error if function is redefined in subsequent run" <|
+        \_ ->
+            let
+                program =
+                    "to a\nend\n"
+
+                logo =
+                    Logo.empty
+                        |> Logo.run program
+                        |> Logo.run program
+
+                env =
+                    Logo.getEnvironment logo
+
+                lastEntry =
+                    List.head env.history
+            in
+            Expect.equal lastEntry (Just ( 2, Error "a is already defined" ))


### PR DESCRIPTION
Before this commit, duplicate definitions only produced an error if they
occurred in a single run of the parser (the parser checked
`state.newFunctions`). With this commit, the parser also checks whether
a function is already defined in `state.existingFunctions`.
