### PR TITLE
Store array ids on stack

### DIFF
--- a/app/elm/Environment.elm
+++ b/app/elm/Environment.elm
@@ -1,5 +1,6 @@
 module Environment exposing
-    ( Environment
+    ( Arrays
+    , Environment
     , Object(..)
     , back
     , clean
@@ -39,6 +40,10 @@ type Object
     = Line Line
 
 
+type alias Arrays =
+    Dict Int { items : Array Type.Value, origin : Int, id : Maybe Int }
+
+
 type alias Environment =
     { history : History
     , objects : List ( Int, Object )
@@ -46,7 +51,7 @@ type alias Environment =
     , penSize : Int
     , color : Color
     , nextId : Int
-    , arrays : Dict Int { items : Array Type.Value, origin : Int, id : Maybe Int }
+    , arrays : Arrays
     , nextArrayId : Int
     }
 

--- a/app/elm/Environment.elm
+++ b/app/elm/Environment.elm
@@ -24,12 +24,15 @@ module Environment exposing
 environment: the state of the turtle, console output etc.
 -}
 
+import Array exposing (Array)
 import Color exposing (Color)
+import Dict exposing (Dict)
 import Environment.History as History exposing (Entry(..), History)
 import Environment.Line as Line exposing (Line)
 import Environment.Turtle as Turtle exposing (State(..), Turtle)
 import Json.Encode as E
 import Math.Vector2 as Vec2 exposing (Vec2)
+import Vm.Type as Type
 
 
 type Object
@@ -43,6 +46,8 @@ type alias Environment =
     , penSize : Int
     , color : Color
     , nextId : Int
+    , arrays : Dict Int ( Array Type.Value, Int )
+    , nextArrayId : Int
     }
 
 
@@ -59,6 +64,8 @@ empty =
     , color = defaultColor
     , penSize = 1
     , nextId = 0
+    , arrays = Dict.empty
+    , nextArrayId = 0
     }
 
 

--- a/app/elm/Environment.elm
+++ b/app/elm/Environment.elm
@@ -1,6 +1,5 @@
 module Environment exposing
-    ( Arrays
-    , Environment
+    ( Environment
     , Object(..)
     , back
     , clean
@@ -25,23 +24,18 @@ module Environment exposing
 environment: the state of the turtle, console output etc.
 -}
 
-import Array exposing (Array)
 import Color exposing (Color)
-import Dict exposing (Dict)
+import Dict
 import Environment.History as History exposing (Entry(..), History)
 import Environment.Line as Line exposing (Line)
 import Environment.Turtle as Turtle exposing (State(..), Turtle)
 import Json.Encode as E
 import Math.Vector2 as Vec2 exposing (Vec2)
-import Vm.Type as Type
+import Vm.Stack exposing (Arrays)
 
 
 type Object
     = Line Line
-
-
-type alias Arrays =
-    Dict Int { items : Array Type.Value, origin : Int, id : Maybe Int }
 
 
 type alias Environment =

--- a/app/elm/Environment.elm
+++ b/app/elm/Environment.elm
@@ -46,7 +46,7 @@ type alias Environment =
     , penSize : Int
     , color : Color
     , nextId : Int
-    , arrays : Dict Int ( Array Type.Value, Int )
+    , arrays : Dict Int { items : Array Type.Value, origin : Int, id : Maybe Int }
     , nextArrayId : Int
     }
 

--- a/app/elm/Vm/Error.elm
+++ b/app/elm/Vm/Error.elm
@@ -21,6 +21,7 @@ type Internal
     | NoInstruction
     | ParsingFailed
     | EvalFailed
+    | ArrayNotFound
 
 
 type Error

--- a/app/elm/Vm/Primitive.elm
+++ b/app/elm/Vm/Primitive.elm
@@ -298,8 +298,8 @@ equalp_ value1 value2 =
         ( _, Type.List _ ) ->
             False
 
-        ( Type.Array _, Type.Array _ ) ->
-            value1 == value2
+        ( Type.Array array1, Type.Array array2 ) ->
+            array1.id == array2.id
 
         ( Type.Array _, _ ) ->
             False

--- a/app/elm/Vm/Stack.elm
+++ b/app/elm/Vm/Stack.elm
@@ -1,6 +1,6 @@
 module Vm.Stack exposing
     ( Arrays
-    , PrimitiveValue(..)
+    , Item(..)
     , Stack
     , Value(..)
     , toValue
@@ -15,29 +15,29 @@ import Vm.Type as Type
 {-| This module mainly holds the definition for a `Value` as it is represented
 on the stack.
 -}
-type PrimitiveValue
+type Value
     = Word String
     | Int Int
     | Float Float
-    | List (List PrimitiveValue)
+    | List (List Value)
     | ArrayId Int
 
 
-type Value
+type Item
     = Void
     | Address Int
-    | Value PrimitiveValue
+    | Value Value
 
 
 type alias Stack =
-    List Value
+    List Item
 
 
 type alias Arrays =
-    Dict Int { items : Array PrimitiveValue, origin : Int, id : Maybe Int }
+    Dict Int { items : Array Value, origin : Int, id : Maybe Int }
 
 
-encodeValue : Arrays -> Value -> E.Value
+encodeValue : Arrays -> Item -> E.Value
 encodeValue arrays value =
     case value of
         Void ->
@@ -50,7 +50,7 @@ encodeValue arrays value =
             E.string <| Type.toDebugString <| toTypeValue arrays primitive
 
 
-toTypeValue : Arrays -> PrimitiveValue -> Type.Value
+toTypeValue : Arrays -> Value -> Type.Value
 toTypeValue arrays value =
     case value of
         Word string ->

--- a/app/elm/Vm/Stack.elm
+++ b/app/elm/Vm/Stack.elm
@@ -2,53 +2,38 @@ module Vm.Stack exposing
     ( PrimitiveValue(..)
     , Stack
     , Value(..)
-    , toTypeValue
     , toValue
     )
 
+import Dict
+import Environment exposing (Arrays)
 import Json.Encode as E
 import Vm.Type as Type
 
 
 {-| This module mainly holds the definition for a `Value` as it is represented
 on the stack.
-
-The introduction of arrays that are treated as references by UCBLogo poses a
-few challenges as the stack did not have to deal with reference values so far.
-This can be seen by the fact that there are now two different types,
-`PrimitiveValue` and `Value`, used to represent values on the stack. At this
-point, they are not clearly separated yet as `PrimitiveValue`, through its
-variant `List`, can hold arrays, and thus reference values. This also leads to
-certain programs’s behaviour diverging from their behaviour when run in
-UCBLogo.
-
-As of February 2024, I think a correct and simple solution would be to
-integrate `ArrayId` into `PrimitiveValue` and convert `PrimitiveValue` to
-`Type.Value` whenever a value is taken from the stack (and vice versa when it
-is put onto the stack). Since this would come at a performance cost, I’m
-slightly hesitant to adopt this solution.
-
 -}
 type PrimitiveValue
     = Word String
     | Int Int
     | Float Float
-    | List (List Type.Value)
+    | List (List PrimitiveValue)
+    | ArrayId Int
 
 
 type Value
     = Void
     | Address Int
     | Value PrimitiveValue
-    | ArrayId Int
 
 
 type alias Stack =
     List Value
 
 
-encodeValue : Value -> E.Value
-encodeValue value =
+encodeValue : Arrays -> Value -> E.Value
+encodeValue arrays value =
     case value of
         Void ->
             E.string "_"
@@ -56,15 +41,12 @@ encodeValue value =
         Address address ->
             E.string <| "@" ++ String.fromInt address
 
-        Value value_ ->
-            E.string <| Type.toDebugString <| toTypeValue value_
-
-        ArrayId id ->
-            E.string <| "array @" ++ String.fromInt id
+        Value primitive ->
+            E.string <| Type.toDebugString <| toTypeValue arrays primitive
 
 
-toTypeValue : PrimitiveValue -> Type.Value
-toTypeValue value =
+toTypeValue : Arrays -> PrimitiveValue -> Type.Value
+toTypeValue arrays value =
     case value of
         Word string ->
             Type.Word string
@@ -76,9 +58,14 @@ toTypeValue value =
             Type.Float float
 
         List list ->
-            Type.List list
+            Type.List (List.map (toTypeValue arrays) list)
+
+        ArrayId id ->
+            Dict.get id arrays
+                |> Maybe.map Type.Array
+                |> Maybe.withDefault (Type.Word "<array not found>")
 
 
-toValue : Stack -> E.Value
-toValue =
-    E.list encodeValue
+toValue : Arrays -> Stack -> E.Value
+toValue arrays =
+    E.list (encodeValue arrays)

--- a/app/elm/Vm/Stack.elm
+++ b/app/elm/Vm/Stack.elm
@@ -1,12 +1,13 @@
 module Vm.Stack exposing
-    ( PrimitiveValue(..)
+    ( Arrays
+    , PrimitiveValue(..)
     , Stack
     , Value(..)
     , toValue
     )
 
-import Dict
-import Environment exposing (Arrays)
+import Array exposing (Array)
+import Dict exposing (Dict)
 import Json.Encode as E
 import Vm.Type as Type
 
@@ -30,6 +31,10 @@ type Value
 
 type alias Stack =
     List Value
+
+
+type alias Arrays =
+    Dict Int { items : Array PrimitiveValue, origin : Int, id : Maybe Int }
 
 
 encodeValue : Arrays -> Value -> E.Value
@@ -62,6 +67,17 @@ toTypeValue arrays value =
 
         ArrayId id ->
             Dict.get id arrays
+                |> Maybe.map
+                    (\array ->
+                        let
+                            { items, origin } =
+                                array
+
+                            typeItems =
+                                Array.map (toTypeValue arrays) items
+                        in
+                        { items = typeItems, origin = origin, id = Just id }
+                    )
                 |> Maybe.map Type.Array
                 |> Maybe.withDefault (Type.Word "<array not found>")
 

--- a/app/elm/Vm/Stack.elm
+++ b/app/elm/Vm/Stack.elm
@@ -1,6 +1,8 @@
 module Vm.Stack exposing
-    ( Stack
+    ( PrimitiveValue(..)
+    , Stack
     , Value(..)
+    , toTypeValue
     , toValue
     )
 
@@ -8,10 +10,37 @@ import Json.Encode as E
 import Vm.Type as Type
 
 
+{-| This module mainly holds the definition for a `Value` as it is represented
+on the stack.
+
+The introduction of arrays that are treated as references by UCBLogo poses a
+few challenges as the stack did not have to deal with reference values so far.
+This can be seen by the fact that there are now two different types,
+`PrimitiveValue` and `Value`, used to represent values on the stack. At this
+point, they are not clearly separated yet as `PrimitiveValue`, through its
+variant `List`, can hold arrays, and thus reference values. This also leads to
+certain programs’s behaviour diverging from their behaviour when run in
+UCBLogo.
+
+As of February 2024, I think a correct and simple solution would be to
+integrate `ArrayId` into `PrimitiveValue` and convert `PrimitiveValue` to
+`Type.Value` whenever a value is taken from the stack (and vice versa when it
+is put onto the stack). Since this would come at a performance cost, I’m
+slightly hesitant to adopt this solution.
+
+-}
+type PrimitiveValue
+    = Word String
+    | Int Int
+    | Float Float
+    | List (List Type.Value)
+
+
 type Value
     = Void
     | Address Int
-    | Value Type.Value
+    | Value PrimitiveValue
+    | ArrayId Int
 
 
 type alias Stack =
@@ -28,7 +57,26 @@ encodeValue value =
             E.string <| "@" ++ String.fromInt address
 
         Value value_ ->
-            E.string <| Type.toDebugString value_
+            E.string <| Type.toDebugString <| toTypeValue value_
+
+        ArrayId id ->
+            E.string <| "array @" ++ String.fromInt id
+
+
+toTypeValue : PrimitiveValue -> Type.Value
+toTypeValue value =
+    case value of
+        Word string ->
+            Type.Word string
+
+        Int int ->
+            Type.Int int
+
+        Float float ->
+            Type.Float float
+
+        List list ->
+            Type.List list
 
 
 toValue : Stack -> E.Value

--- a/app/elm/Vm/Type.elm
+++ b/app/elm/Vm/Type.elm
@@ -41,7 +41,7 @@ type Value
     | Int Int
     | Float Float
     | List (List Value)
-    | Array (Array Value) Int
+    | Array { items : Array Value, origin : Int, id : Maybe Int }
 
 
 type Error
@@ -84,10 +84,10 @@ toString value =
                 |> List.map inList
                 |> String.join " "
 
-        Array array _ ->
+        Array { items } ->
             let
                 string =
-                    array
+                    items
                         |> Array.toList
                         |> List.map toDebugString
                         |> String.join " "

--- a/app/elm/Vm/Vm.elm
+++ b/app/elm/Vm/Vm.elm
@@ -229,10 +229,10 @@ incrementProgramCounter vm =
     { vm | programCounter = vm.programCounter + 1 }
 
 
-{-| Convert a `Stack.PrimitiveValue` to a `Type.Value`. If the value is a
+{-| Convert a `Stack.Value` to a `Type.Value`. If the value is a
 `Stack.ArrayId`, use the VM’s enviromnent to resolve it to an array.
 -}
-toTypeValue : Stack.PrimitiveValue -> Vm -> Result Error Type.Value
+toTypeValue : Stack.Value -> Vm -> Result Error Type.Value
 toTypeValue value vm =
     case value of
         Stack.Word string ->
@@ -281,11 +281,11 @@ toTypeValue value vm =
                 |> Result.map Type.Array
 
 
-{-| Convert a `Type.Value` to a `Stack.PrimitiveValue`. If the value is a
+{-| Convert a `Type.Value` to a `Stack.Value`. If the value is a
 `Type.Array`, assign it an id and store it in the VM’s enviromnent.
 -}
-toStackPrimitiveValue : Type.Value -> Vm -> ( Stack.PrimitiveValue, Vm )
-toStackPrimitiveValue value vm =
+toStackValue : Type.Value -> Vm -> ( Stack.Value, Vm )
+toStackValue value vm =
     case value of
         Type.Word word ->
             ( Stack.Word word, vm )
@@ -303,7 +303,7 @@ toStackPrimitiveValue value vm =
                         (\value_ ( accList, accVm ) ->
                             let
                                 ( stackValue, newAccVm ) =
-                                    toStackPrimitiveValue value_ accVm
+                                    toStackValue value_ accVm
                             in
                             ( stackValue :: accList, newAccVm )
                         )
@@ -327,7 +327,7 @@ toStackPrimitiveValue value vm =
                                 (\value_ ( accList, accVm ) ->
                                     let
                                         ( stackValue, newAccVm ) =
-                                            toStackPrimitiveValue value_ accVm
+                                            toStackValue value_ accVm
                                     in
                                     ( stackValue :: accList, newAccVm )
                                 )
@@ -361,7 +361,7 @@ pushValue1 : Type.Value -> Vm -> Vm
 pushValue1 value vm =
     let
         ( newValue, newVm ) =
-            toStackPrimitiveValue value vm
+            toStackValue value vm
     in
     { newVm | stack = Stack.Value newValue :: newVm.stack }
 

--- a/tests/Test/Encode.elm
+++ b/tests/Test/Encode.elm
@@ -6,6 +6,7 @@ module Test.Encode exposing
     , encodeAndDecodeVms
     )
 
+import Dict
 import Environment.History exposing (Entry(..))
 import Expect
 import Json.Decode as D
@@ -127,11 +128,11 @@ encodeAndDecodeStack =
                         [ Stack.Void
                         , Stack.Address 10
                         , Stack.Value <| Stack.Word "word"
-                        , Stack.Value <| Stack.List [ word, Type.List [ word ] ]
+                        , Stack.Value <| Stack.List [ Stack.Word "word", Stack.List [ Stack.Word "word" ] ]
                         ]
 
                     value =
-                        Stack.toValue stack
+                        Stack.toValue Dict.empty stack
                 in
                 D.decodeValue (D.list D.string) value
                     |> Expect.ok

--- a/tests/Test/Encode.elm
+++ b/tests/Test/Encode.elm
@@ -94,11 +94,6 @@ word =
     Type.Word "word"
 
 
-list : Type.Value
-list =
-    Type.List [ word, Type.List [ word ] ]
-
-
 encodeAndDecodeScope : Test
 encodeAndDecodeScope =
     describe "Scope" <|
@@ -129,7 +124,11 @@ encodeAndDecodeStack =
             \_ ->
                 let
                     stack =
-                        [ Stack.Void, Stack.Address 10, Stack.Value word, Stack.Value list ]
+                        [ Stack.Void
+                        , Stack.Address 10
+                        , Stack.Value <| Stack.Word "word"
+                        , Stack.Value <| Stack.List [ word, Type.List [ word ] ]
+                        ]
 
                     value =
                         Stack.toValue stack

--- a/tests/Test/Vm.elm
+++ b/tests/Test/Vm.elm
@@ -71,7 +71,7 @@ vmWithTwoInstructions =
                 Expect.equal vm.programCounter 2
         , test "stack gets changed" <|
             \_ ->
-                Expect.equal vm.stack [ Stack.Value <| Type.Word "w" ]
+                Expect.equal vm.stack [ Stack.Value <| Stack.Word "w" ]
         ]
 
 
@@ -91,7 +91,7 @@ vmWithVariables =
     in
     test "setting and getting a variable" <|
         \_ ->
-            Expect.equal vm.stack [ Stack.Value <| Type.Word "word" ]
+            Expect.equal vm.stack [ Stack.Value <| Stack.Word "word" ]
 
 
 vmWithIntrospection : Test
@@ -107,7 +107,7 @@ vmWithIntrospection =
     in
     test "calling repcount outside a loop" <|
         \_ ->
-            Expect.equal vm.stack [ Stack.Value <| Type.Int -1 ]
+            Expect.equal vm.stack [ Stack.Value <| Stack.Int -1 ]
 
 
 vmWithConditionalPrint : Test
@@ -260,8 +260,8 @@ vmWithFlip =
         vm =
             { emptyVm
                 | stack =
-                    [ Stack.Value (Type.Word "a")
-                    , Stack.Value (Type.Word "b")
+                    [ Stack.Value (Stack.Word "a")
+                    , Stack.Value (Stack.Word "b")
                     ]
                 , instructions =
                     [ Flip ]
@@ -273,8 +273,8 @@ vmWithFlip =
         [ test "flips topmost stack values" <|
             \_ ->
                 Expect.equal vm.stack
-                    [ Stack.Value (Type.Word "b")
-                    , Stack.Value (Type.Word "a")
+                    [ Stack.Value (Stack.Word "b")
+                    , Stack.Value (Stack.Word "a")
                     ]
         ]
 


### PR DESCRIPTION
- Store arrays in `Environment`
- Turn array into record to store id
- Use id to check for array equality
- Extract `toStackValue`
- Merge `ArrayId` into `PrimitiveValue`
- Always store arrays as ids on the stack
- Rename `Value` and `PrimitiveValue` to `Item` and `Value`
