### PR TITLE
Improve error messages when run is used

### DIFF
--- a/app/elm/Compiler/Ast.elm
+++ b/app/elm/Compiler/Ast.elm
@@ -285,6 +285,16 @@ compileBranch controlStructure context children =
             compileNonEmptyBranch context (Nonempty first rest)
 
 
+toInstructionContext : Context -> Instruction.Context
+toInstructionContext context =
+    case context of
+        Statement ->
+            Instruction.Statement
+
+        Expression { caller } ->
+            Instruction.Expression { caller = caller }
+
+
 {-| Compile an AST node to a list of VM instructions.
 
 This function inserts instructions that check at runtime whether or not a
@@ -788,8 +798,12 @@ compile context node =
             ]
 
         Run node_ ->
+            let
+                instructionContext =
+                    toInstructionContext context
+            in
             [ compileInContext (Expression { caller = "run" }) node_
-            , [ Eval ]
+            , [ EvalInContext instructionContext ]
             ]
                 |> List.concat
 

--- a/app/elm/Compiler/Ast.elm
+++ b/app/elm/Compiler/Ast.elm
@@ -837,14 +837,14 @@ compile context node =
             [ Instruction.Raise error ]
 
 
-compileProgram : Program -> CompiledProgram
-compileProgram { functions, body } =
+compileProgram : Context -> Program -> CompiledProgram
+compileProgram context { functions, body } =
     let
         compiledFunctions =
             List.map compileFunction functions
 
         instructions =
-            List.concatMap (compileInContext Statement) body
+            List.concatMap (compileInContext context) body
     in
     { instructions = instructions
     , compiledFunctions = compiledFunctions

--- a/app/elm/Logo.elm
+++ b/app/elm/Logo.elm
@@ -14,10 +14,9 @@ module Logo exposing
 import Compiler.Ast as Ast exposing (Context(..))
 import Compiler.Linker as Linker
 import Compiler.Parser as Parser
-import Dict
 import Environment exposing (Environment)
 import Environment.History exposing (History)
-import Parser.Advanced as Parser exposing (DeadEnd)
+import Parser.Advanced as Parser
 import StandardLibrary
 import Vm.Vm as Vm exposing (State(..), Vm)
 
@@ -85,7 +84,7 @@ compile program logo =
         Ok newVm ->
             Logo <| Paused { newVm | environment = Environment.input program newVm.environment }
 
-        Err error ->
+        Err _ ->
             Logo <| Done { vm | environment = Environment.error "parse error" vm.environment }
 
 

--- a/app/elm/Logo.elm
+++ b/app/elm/Logo.elm
@@ -11,7 +11,7 @@ module Logo exposing
     , step
     )
 
-import Compiler.Ast as Ast
+import Compiler.Ast as Ast exposing (Context(..))
 import Compiler.Linker as Linker
 import Compiler.Parser as Parser
 import Dict
@@ -73,7 +73,7 @@ compile program logo =
             program
                 |> Parser.run parser
                 |> Result.mapError ParseError
-                |> Result.map Ast.compileProgram
+                |> Result.map (Ast.compileProgram Statement)
 
         result =
             compiledProgram

--- a/app/elm/Main.elm
+++ b/app/elm/Main.elm
@@ -10,7 +10,6 @@ import Css
         , boxShadow5
         , height
         , left
-        , none
         , overflowY
         , pct
         , position

--- a/app/elm/StandardLibrary.elm
+++ b/app/elm/StandardLibrary.elm
@@ -1,6 +1,6 @@
 module StandardLibrary exposing (compiledFunctions)
 
-import Compiler.Ast as Ast exposing (CompiledFunction)
+import Compiler.Ast as Ast exposing (CompiledFunction, Context(..))
 import Compiler.Parser as Parser
 import Dict
 import Parser.Advanced as Parser
@@ -45,7 +45,7 @@ compiledFunctions =
         compiledProgram =
             functions
                 |> Parser.run parser
-                |> Result.map Ast.compileProgram
+                |> Result.map (Ast.compileProgram Statement)
     in
     compiledProgram
         |> Result.map .compiledFunctions

--- a/app/elm/Vm/Instruction.elm
+++ b/app/elm/Vm/Instruction.elm
@@ -1,10 +1,24 @@
-module Vm.Instruction exposing (Instruction(..))
+module Vm.Instruction exposing (Context(..), Instruction(..))
 
 import Vm.Command as C
 import Vm.Exception exposing (Exception)
 import Vm.Introspect as I
 import Vm.Primitive as P
 import Vm.Type as Type
+
+
+{-| Represents the context a Vm instruction can be executed in.
+
+This is relevant for whether or not to raise exceptions about unused or missing
+return values.
+
+If the context is `Statement` the evaluated code is expected to not return a
+value, if it is `Expression` it is expected to return a value.
+
+-}
+type Context
+    = Statement
+    | Expression { caller : String }
 
 
 {-| Represent instructions a `Vm` can execute.
@@ -19,7 +33,7 @@ type Instruction
     | Thing
     | Introspect0 I.Introspect0
     | Introspect1 I.Introspect1
-    | Eval
+    | EvalInContext Context
     | Eval1 P.Primitive1
     | Eval2 P.Primitive2
     | Eval3 P.Primitive3

--- a/app/elm/Vm/Vm.elm
+++ b/app/elm/Vm/Vm.elm
@@ -16,7 +16,7 @@ machine as well as functions for running it.
 -}
 
 import Array exposing (Array)
-import Compiler.Ast as Ast exposing (CompiledFunction, CompiledProgram, Program)
+import Compiler.Ast as Ast exposing (CompiledFunction, CompiledProgram, Context(..), Program)
 import Compiler.Linker as Linker exposing (LinkedProgram)
 import Compiler.Parser as Parser exposing (Parser)
 import Dict exposing (Dict)
@@ -489,7 +489,7 @@ parseAndCompileProgram : Parser Program -> String -> Result Error CompiledProgra
 parseAndCompileProgram parser =
     Parser.run parser
         >> Result.mapError (always <| Internal ParsingFailed)
-        >> Result.map Ast.compileProgram
+        >> Result.map (Ast.compileProgram Statement)
 
 
 parseAndEvalInstructions : Vm -> List Type.Value -> Result Error Vm

--- a/tests/Test/Error.elm
+++ b/tests/Test/Error.elm
@@ -102,6 +102,7 @@ print foo "baz""" "foo did not output to print"
         , printsError "1 > print 3" "print did not output to >"
         , printsError "print ifelse \"true [] []" "ifelse did not output to print"
         , printsError "print ifelse \"false [] []" "ifelse did not output to print"
+        , printsError "print run [print \"a]" "print did not output to print"
         ]
 
 
@@ -136,6 +137,7 @@ foo "baz"""
         , printsError "if 1 = 1 [ minus 1 ]" "You don’t say what to do with -1"
         , printsError "ifelse \"true [ 5 ] [ 6 ]" "You don’t say what to do with 5"
         , printsError "butfirst [ 1 ]" "You don’t say what to do with []"
+        , printsError "run [\"a]" "You don’t say what to do with a"
         ]
 
 

--- a/tests/Test/Vm.elm
+++ b/tests/Test/Vm.elm
@@ -8,7 +8,7 @@ import Expect
 import Test exposing (..)
 import Vm.Command as C
 import Vm.Exception as Exception
-import Vm.Instruction exposing (Instruction(..))
+import Vm.Instruction exposing (Context(..), Instruction(..))
 import Vm.Introspect as I
 import Vm.Primitive as P
 import Vm.Scope as Scope
@@ -21,6 +21,7 @@ emptyVm : Vm
 emptyVm =
     { instructions = Array.empty
     , programCounter = 0
+    , executionHaltedDueToError = False
     , stack = []
     , scopes = Scope.empty
     , environment = Environment.empty
@@ -428,7 +429,7 @@ vmWithEvalOnList =
             { emptyVm
                 | instructions =
                     [ PushValue (Type.List [ Type.Word "print", Type.Word "\"word" ])
-                    , Eval
+                    , EvalInContext Statement
                     ]
                         |> Array.fromList
             }
@@ -449,7 +450,7 @@ vmWithEvalOnWord =
                     [ PushValue (Type.Int 90)
                     , Command1 { name = "forward", f = C.forward }
                     , PushValue (Type.Word "home")
-                    , Eval
+                    , EvalInContext Statement
                     , PushValue (Type.Int 90)
                     , Command1 { name = "back", f = C.back }
                     ]


### PR DESCRIPTION
- Pass context to `compileProgram`
- Remove unused code
- Run `Eval` in context
